### PR TITLE
Maps now fills the right side of the Explore page and fits neatly int…

### DIFF
--- a/theshaft/src/client/components/Maps.js
+++ b/theshaft/src/client/components/Maps.js
@@ -80,7 +80,10 @@ export default class Maps extends Component {
         popupInfo: this.props.popupInfo,
         popupId: this.props.popupId,
         popupIndex: popupIndex
-      }
+      },
+      //width and height are passed in from outside
+      height: this.props.height,
+      width: this.props.width
     };    
     this.handleViewportChange = this.handleViewportChange.bind(this);
   }
@@ -108,8 +111,9 @@ export default class Maps extends Component {
           mapStyle={"mapbox://styles/mapbox/basic-v9"}
           latitude={view.latitude}
           longitude={view.longitude}
-          width={"100%"}
-          height={"400px"}
+          //width and height are passed in from outside
+          width={this.props.width}
+          height={this.props.height}
           zoom={view.zoom}
           onViewportChange={this.handleViewportChange}
         >

--- a/theshaft/src/client/containers/Dorm.js
+++ b/theshaft/src/client/containers/Dorm.js
@@ -270,6 +270,8 @@ export default class Dorm extends React.PureComponent {
               longitudes={[-74.006, -74.007, -74.008]}
               popupInfo={["Carman", "McBain", "John Jay"]}
               popupId={["Carman", "McBain", "JohnJay"]}
+              width={"100%"}
+              height={"300px"}
             />
             <ProCon
               pros={this.state.dormInfo.pros}

--- a/theshaft/src/client/containers/Explore.js
+++ b/theshaft/src/client/containers/Explore.js
@@ -2,21 +2,13 @@ import React, { Component } from 'react';
 import styled from "styled-components";
 import { Route, Link, BrowserRouter as Router } from 'react-router-dom';
 import DormButton from '../components/DormButton';
-import '../css/Explore.css';
+//import '../css/Explore.css';
 import Dorm from './Dorm.js';
 import Updater from '../components/Updater';
 import ExploreSidebar from "../components/ExploreSidebar";
 //import "../css/Explore.css";
 import map from "../assets/map.png";
 import Maps from "../components/Maps";
-
-// div.explore {
-//   width: 100%;
-//   height: 100%;
-//   padding: 0 auto;
-//   overflow: hidden;
-//   /* flex-direction: row; */
-// }
 
 let ExploreContainer = styled.div`
   width: 100%;
@@ -62,12 +54,12 @@ let ColTwo = styled.div`
   position: fixed;
   padding-left: 1em;
   float: right;
-  // width: 67%;
+  height: 100%;
   right: 0;
   top: 0;
-  z-index:1;
+  //z-index:1;
   // display: flex;
-  //flex-direction: column;
+  flex-direction: column;
   width: ${(mobile) => mobile ? `67%`: `50%`};
   //width: 50%;
 `
@@ -171,10 +163,16 @@ export default class Explore extends Component {
           </SideBar>
         </ColOne>
         <ColTwo>
-          <Maps latitudes={[40.7128, 40.7129, 40.7128]} longitudes={[-74.006, -74.007, -74.008]} popupInfo={["Carman", "McBain", "John Jay"]} popupId={["Carman", "McBain", "JohnJay"]}/>
-        {/* <div className="map">
-            <img src={map} />
-        </div> */}
+          <MapView>
+            <Maps 
+              latitudes={[40.7128, 40.7129, 40.7128]} 
+              longitudes={[-74.006, -74.007, -74.008]} 
+              popupInfo={["Carman", "McBain", "John Jay"]} 
+              popupId={["Carman", "McBain", "JohnJay"]}
+              width={"100%"}
+              height={"900px"}
+              />
+          </MapView>
         </ColTwo>
         <Updater interval="15" />
       </ExploreContainer>


### PR DESCRIPTION
…o the Dorm page. The width and height are to be passed from Explore.js and Dorms.js into the Maps component to provide this functionality. `width` should be `"100%"` and `height` should be a pixel value, currently 900px for Explore and 100px for Dorm.