### PR TITLE
Fixed Elliot Hall Dorm Page! :smile:

### DIFF
--- a/src/client/src/containers/Dorm.js
+++ b/src/client/src/containers/Dorm.js
@@ -184,7 +184,7 @@ const dorm_name_map = {
   "601W110thSt.": "601 W 110th St.",
   "CathedralGardens": "Cathedral Gardens",
   "HewittHall": "Hewitt Hall",
-  "ElliottHall": "Elliott Hall",
+  "ElliotHall": "Elliot Hall",
   "SulzbergerTower": "Sulzberger Tower",
   "BroadwayHall": "Broadway Hall",
   "CarltonArms": "Carlton Arms",


### PR DESCRIPTION
# Description

Minor spelling mistake in dorm_name_map variable. dorm_name_map extracts and changes the format of dorm names from the url in preparation for api requests.

```js
fetch(`/api/getDormPhotos/${dormName}`
```
 
Elliot Hall was misspelled "Elliot**t** Hall" creating a problem requesting information for that page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New frontend feature (change which affects what users see)
- [ ] Backend change (fix that would cause existing functionality or data to not work as expected)
